### PR TITLE
Moved Aux from Music player to Drivers and changed subsequent CAN data

### DIFF
--- a/EpsilonCCS/Inc/Data/DriverControlData.h
+++ b/EpsilonCCS/Inc/Data/DriverControlData.h
@@ -56,6 +56,7 @@ struct DriverInputs
     unsigned char pushToTalk;
     unsigned char horn;
     unsigned char reset;
+    unsigned char aux;
 };
 
 struct DriverControlData
@@ -66,7 +67,6 @@ struct DriverControlData
     unsigned short int acceleration;
     unsigned short int regenBraking;
     struct DriverInputs driverInputs;
-    unsigned char aux;
 };
 
 extern struct DriverControlData driverControlData;

--- a/EpsilonCCS/Inc/Data/DriverControlData.h
+++ b/EpsilonCCS/Inc/Data/DriverControlData.h
@@ -15,11 +15,10 @@
 #define INTERIOR_MASK 0x40
 
 // Music Inputs
-#define AUX_MASK 0x01
-#define VOLUME_UP_MASK 0x02
-#define VOLUME_DOWN_MASK 0x04
-#define NEXT_SONG_MASK 0x08
-#define PREV_SONG_MASK 0x10
+#define VOLUME_UP_MASK 0x01
+#define VOLUME_DOWN_MASK 0x02
+#define NEXT_SONG_MASK 0x04
+#define PREV_SONG_MASK 0x8
 
 // Driver Inputs
 #define BRAKES_MASK 0x01
@@ -28,6 +27,7 @@
 #define PUSH_TO_TALK_MASK 0x08
 #define HORN_MASK 0x10
 #define RESET_MASK 0x20
+#define AUX_MASK 0x40
 
 struct LightsInputs
 {

--- a/EpsilonCCS/Inc/Data/DriverControlData.h
+++ b/EpsilonCCS/Inc/Data/DriverControlData.h
@@ -18,7 +18,7 @@
 #define VOLUME_UP_MASK 0x01
 #define VOLUME_DOWN_MASK 0x02
 #define NEXT_SONG_MASK 0x04
-#define PREV_SONG_MASK 0x8
+#define PREV_SONG_MASK 0x08
 
 // Driver Inputs
 #define BRAKES_MASK 0x01

--- a/EpsilonCCS/Inc/Data/DriverControlData.h
+++ b/EpsilonCCS/Inc/Data/DriverControlData.h
@@ -42,7 +42,6 @@ struct LightsInputs
 
 struct MusicInputs
 {
-    unsigned char aux;
     unsigned char volumeUp;
     unsigned char volumeDown;
     unsigned char nextSong;
@@ -67,6 +66,7 @@ struct DriverControlData
     unsigned short int acceleration;
     unsigned short int regenBraking;
     struct DriverInputs driverInputs;
+    unsigned char aux;
 };
 
 extern struct DriverControlData driverControlData;

--- a/EpsilonCCS/Src/CanParsers/DriverControlsCanParser.c
+++ b/EpsilonCCS/Src/CanParsers/DriverControlsCanParser.c
@@ -49,7 +49,6 @@ void parseDriverControlsLightsInput(uint8_t* data)
 
 void parseDriverControlsMusicInput(uint8_t* data)
 {
-    driverControlData.musicInputs.aux = data[0] & AUX_MASK;
     driverControlData.musicInputs.volumeUp = data[0] & VOLUME_UP_MASK;
     driverControlData.musicInputs.volumeDown = data[0] & VOLUME_DOWN_MASK;
     driverControlData.musicInputs.nextSong = data[0] & NEXT_SONG_MASK;
@@ -71,4 +70,5 @@ void parseDriverControlsDriverInput(uint8_t* data)
     driverControlData.driverInputs.pushToTalk = data[3] & PUSH_TO_TALK_MASK;
     driverControlData.driverInputs.horn = data[3] & HORN_MASK;
     driverControlData.driverInputs.reset = data[3] & RESET_MASK;
+    driverControlData.driverInputs.aux = data[3] & AUX_MASK;
 }

--- a/EpsilonCCS/Src/TelemetryReporting/TelemetryReporting.c
+++ b/EpsilonCCS/Src/TelemetryReporting/TelemetryReporting.c
@@ -161,10 +161,9 @@ void sendDriverControls()
     unsigned char driverControlsBoardAliveArray[] = {messageIsRecent(driverControlData.lastReceived)};
     writeBoolsIntoArray(packetPayload, 1, driverControlsBoardAliveArray, 1);
     writeBoolsIntoArray(packetPayload, 2, &driverControlData.lightsInputs, 7);
-    writeBoolsIntoArray(packetPayload, 3, &driverControlData.musicInputs, 5);
-    writeUShortIntoArray(packetPayload, 4, driverControlData.acceleration);
+    writeBoolsIntoArray(packetPayload, 3, &driverControlData.musicInputs, 4);
     writeUShortIntoArray(packetPayload, 6, driverControlData.regenBraking);
-    writeBoolsIntoArray(packetPayload, 8, &driverControlData.driverInputs, 6);
+    writeBoolsIntoArray(packetPayload, 8, &driverControlData.driverInputs, 7);
 
     addChecksum(packetPayload, DRIVER_CONTROLS_LENGTH);
     unsigned char packet[unframedPacketLength + FRAMING_LENGTH_INCREASE];

--- a/EpsilonDriverControls/Src/DriverControls.c
+++ b/EpsilonDriverControls/Src/DriverControls.c
@@ -121,6 +121,7 @@ void sendDriverTask(void const* arg)
         msg->Data[3] |= 0x10 * !HAL_GPIO_ReadPin(HORN_GPIO_Port, HORN_Pin);
         msg->Data[3] |= 0x20 * !HAL_GPIO_ReadPin(RESET_GPIO_Port, RESET_Pin);
         msg->Data[3] |= 0x40 * !HAL_GPIO_ReadPin(AUX_GPIO_Port, AUX_Pin);
+        //Send CAN Message
         osMessagePut(canQueue, (uint32_t)msg, osWaitForever);
     }
 }

--- a/EpsilonDriverControls/Src/DriverControls.c
+++ b/EpsilonDriverControls/Src/DriverControls.c
@@ -62,11 +62,10 @@ void sendMusicTask(void const* arg)
         // Populate CAN Message
         msg->StdId = MUSIC_STDID;
         msg->DLC = MUSIC_DLC;
-        msg->Data[0] |= 0x01 * !HAL_GPIO_ReadPin(AUX_GPIO_Port, AUX_Pin);
-        msg->Data[0] |= 0x02 * !HAL_GPIO_ReadPin(VOLUME_UP_GPIO_Port, VOLUME_UP_Pin);
-        msg->Data[0] |= 0x03 * !HAL_GPIO_ReadPin(VOLUME_DOWN_GPIO_Port, VOLUME_DOWN_Pin);
+        msg->Data[0] |= 0x01 * !HAL_GPIO_ReadPin(VOLUME_UP_GPIO_Port, VOLUME_UP_Pin);
+        msg->Data[0] |= 0x02 * !HAL_GPIO_ReadPin(VOLUME_DOWN_GPIO_Port, VOLUME_DOWN_Pin);
         msg->Data[0] |= 0x04 * !HAL_GPIO_ReadPin(NEXT_SONG_GPIO_Port, NEXT_SONG_Pin);
-        msg->Data[0] |= 0x10 * !HAL_GPIO_ReadPin(LAST_SONG_GPIO_Port, LAST_SONG_Pin);
+        msg->Data[0] |= 0x08 * !HAL_GPIO_ReadPin(LAST_SONG_GPIO_Port, LAST_SONG_Pin);
         // Send CAN Message
         osMessagePut(canQueue, (uint32_t)msg, osWaitForever);
     }
@@ -121,7 +120,7 @@ void sendDriverTask(void const* arg)
         msg->Data[3] |= 0x08 * !HAL_GPIO_ReadPin(PUSH_TO_TALK_GPIO_Port, PUSH_TO_TALK_Pin);
         msg->Data[3] |= 0x10 * !HAL_GPIO_ReadPin(HORN_GPIO_Port, HORN_Pin);
         msg->Data[3] |= 0x20 * !HAL_GPIO_ReadPin(RESET_GPIO_Port, RESET_Pin);
-        // Send CAN Message
+        msg->Data[3] |= 0x40 * !HAL_GPIO_ReadPin(AUX_GPIO_Port, AUX_Pin);
         osMessagePut(canQueue, (uint32_t)msg, osWaitForever);
     }
 }


### PR DESCRIPTION
Moved Aux from Music player to Driver. Previous Music player had Can data in hexadecimal with 1, 2, 3, 4, 10. 3 should not be there because it would mean 2 outputs, Aux and Volume Up. 