### PR TITLE
Alternate fix to Discharge contactor issue

### DIFF
--- a/EpsilonAuxBMS/Src/UpdateChargeAllowanceTask.c
+++ b/EpsilonAuxBMS/Src/UpdateChargeAllowanceTask.c
@@ -115,7 +115,10 @@ void updateChargeAllowanceTask(void const* arg)
             }
         }
 
-        if (DEFAULT_VOLTAGE_UNITS * orionStatus.minCellVoltage < MIN_CELL_VOLTAGE)
+        // Min Cell voltage is initialized to be zero. 
+        // Check to see if the minCellVoltage has been updated through CAN, 
+        // so to not trigger this statement immediately on startup
+        if (orionStatus.minCellVoltage > 0 && (DEFAULT_VOLTAGE_UNITS * orionStatus.minCellVoltage < MIN_CELL_VOLTAGE))
         {
             voltagesInRange = 0;
 

--- a/EpsilonAuxBMS/Src/main.c
+++ b/EpsilonAuxBMS/Src/main.c
@@ -145,9 +145,7 @@ int main(void)
     // Start with orionBatteryVoltagesOk set to 1 to allow contactor setting
     orionStatus.batteryVoltagesInRange = 1;
 
-    // Start with minCellVoltage to be a high value, so it doesn't trigger the
-    // Min Cell voltage check in UpdateChargeAllowance right away
-    orionStatus.minCellVoltage = 50000;
+    orionStatus.minCellVoltage = 0;
 
     // Setup for next CAN Receive Interrupt
     if (HAL_CAN_Receive_IT(&hcan1, CAN_FIFO0) != HAL_OK)


### PR DESCRIPTION
I think the previous fix will introduce some issues, in the event that CAN messaging isn't working, the check will no longer stop the contactors from closing. Here's an alternate fix.