### PR TITLE
Mob/LapLoggingButton

### DIFF
--- a/EpsilonCCS/Inc/Data/DriverControlData.h
+++ b/EpsilonCCS/Inc/Data/DriverControlData.h
@@ -28,6 +28,7 @@
 #define HORN_MASK 0x10
 #define RESET_MASK 0x20
 #define AUX_MASK 0x40
+#define LAP_MASK 0x80
 
 struct LightsInputs
 {
@@ -57,6 +58,7 @@ struct DriverInputs
     unsigned char horn;
     unsigned char reset;
     unsigned char aux;
+    unsigned char lap;
 };
 
 struct DriverControlData

--- a/EpsilonCCS/Src/CanParsers/DriverControlsCanParser.c
+++ b/EpsilonCCS/Src/CanParsers/DriverControlsCanParser.c
@@ -71,4 +71,5 @@ void parseDriverControlsDriverInput(uint8_t* data)
     driverControlData.driverInputs.horn = data[3] & HORN_MASK;
     driverControlData.driverInputs.reset = data[3] & RESET_MASK;
     driverControlData.driverInputs.aux = data[3] & AUX_MASK;
+    driverControlData.driverInputs.lap = data[3] & LAP_MASK;
 }

--- a/EpsilonCCS/Src/TelemetryReporting/TelemetryReporting.c
+++ b/EpsilonCCS/Src/TelemetryReporting/TelemetryReporting.c
@@ -166,7 +166,7 @@ void sendDriverControls()
     writeBoolsIntoArray(packetPayload, 3, &driverControlData.musicInputs, 4);
     writeUShortIntoArray(packetPayload, 4, driverControlData.acceleration);
     writeUShortIntoArray(packetPayload, 6, driverControlData.regenBraking);
-    writeBoolsIntoArray(packetPayload, 8, &driverControlData.driverInputs, 7);
+    writeBoolsIntoArray(packetPayload, 8, &driverControlData.driverInputs, 8);
 
     addChecksum(packetPayload, DRIVER_CONTROLS_LENGTH);
     unsigned char packet[unframedPacketLength + FRAMING_LENGTH_INCREASE];

--- a/EpsilonDriverControls/Inc/DriverControls.h
+++ b/EpsilonDriverControls/Inc/DriverControls.h
@@ -40,6 +40,9 @@
 
 #define AUXBMS_INPUT_STDID 0x721U
 
+#define LAP_PIN CONTEXT_Pin
+#define LAP_GPIO_PORT CONTEXT_GPIO_Port
+
 extern CAN_HandleTypeDef hcan2; // main.c
 extern ADC_HandleTypeDef hadc1;
 extern ADC_HandleTypeDef hadc2;

--- a/EpsilonDriverControls/Src/DriverControls.c
+++ b/EpsilonDriverControls/Src/DriverControls.c
@@ -91,6 +91,7 @@ void sendLightsTask(void const* arg)
         msg->Data[0] |= 0x10 * !HAL_GPIO_ReadPin(LSIGNAL_GPIO_Port, LSIGNAL_Pin);
         msg->Data[0] |= 0x20 * !HAL_GPIO_ReadPin(HAZARDS_GPIO_Port, HAZARDS_Pin);
         msg->Data[0] |= 0x40 * !HAL_GPIO_ReadPin(INTERIOR_GPIO_Port, INTERIOR_Pin);
+
         // Send CAN Message
         osMessagePut(canQueue, (uint32_t)msg, osWaitForever);
     }
@@ -121,6 +122,7 @@ void sendMusicTask(void const* arg)
 
 void sendDriverTask(void const* arg)
 {
+
     uint32_t prevWakeTime = osKernelSysTick();
 
     for (;;)
@@ -147,6 +149,9 @@ void sendDriverTask(void const* arg)
         msg->Data[3] |= 0x10 * !HAL_GPIO_ReadPin(HORN_GPIO_Port, HORN_Pin);
         msg->Data[3] |= 0x20 * !HAL_GPIO_ReadPin(RESET_GPIO_Port, RESET_Pin);
         msg->Data[3] |= 0x40 * !HAL_GPIO_ReadPin(AUX_GPIO_Port, AUX_Pin);
+        msg->Data[3] |= 0x80 * !HAL_GPIO_ReadPin(LAP_GPIO_PORT, LAP_PIN);
+
+
         //Send CAN Message
         osMessagePut(canQueue, (uint32_t)msg, osWaitForever);
     }


### PR DESCRIPTION
Added a bit to driverInputs for lap button
Made Macros for LAP_PIN and LAP_GPIO_PORT to point to the CONTEXT Pin and Port
Changing context button to lap on STM was causing build issues