### PR TITLE
SFT-134 Fix ProtectionTripping to use chargeSense instead of orionChargeSense

### DIFF
--- a/EpsilonAuxBMS/Inc/Trip.h
+++ b/EpsilonAuxBMS/Inc/Trip.h
@@ -1,4 +1,9 @@
+#pragma once
 
 int chargeShouldTrip();
 
 int dischargeShouldTrip();
+
+int protectionTripping();
+
+int carShouldTrip();

--- a/EpsilonAuxBMS/Src/Trip.c
+++ b/EpsilonAuxBMS/Src/Trip.c
@@ -1,5 +1,6 @@
 #include "Trip.h"
 #include "OrionStatus.h"
+#include "AuxBmsTasks.h"
 
 static const float ORION_MAX_CELL_VOLTAGE = 4.20; // Much match orion bms value
 static const float ORION_MIN_CELL_VOLTAGE = 2.55;
@@ -92,4 +93,22 @@ int dischargeShouldTrip()
     }
 
     return dischargeShouldTrip;
+}
+
+int protectionTripping()
+{
+    // If the charge contactor is off, but we are still charging, trip
+    const uint8_t chargeSense = !HAL_GPIO_ReadPin(CHARGE_SENSE_GPIO_Port, CHARGE_SENSE_Pin);
+
+    if (!chargeSense && orionStatus.packCurrent < 0)
+    {
+        return 1;
+    }
+
+    return 0;
+}
+
+int carShouldTrip()
+{
+    return (chargeShouldTrip() || dischargeShouldTrip() || protectionTripping());
 }

--- a/EpsilonAuxBMS/Src/UpdateChargeAllowanceTask.c
+++ b/EpsilonAuxBMS/Src/UpdateChargeAllowanceTask.c
@@ -56,28 +56,11 @@ void updateChargeAllowanceTask(void const* arg)
 
         if (auxStatus.startUpSequenceDone)
         {
-            unsigned dischargeSense = HAL_GPIO_ReadPin(ORION_DISCHARGE_ENABLE_SENSE_GPIO_Port, ORION_DISCHARGE_ENABLE_SENSE_Pin);
-            unsigned chargeSense = HAL_GPIO_ReadPin(ORION_CHARGE_ENABLE_SENSE_GPIO_Port, ORION_CHARGE_ENABLE_SENSE_Pin);
+            unsigned orionDischargeEnableSense = HAL_GPIO_ReadPin(ORION_DISCHARGE_ENABLE_SENSE_GPIO_Port, ORION_DISCHARGE_ENABLE_SENSE_Pin);
+            unsigned orionChargeEnableSense = HAL_GPIO_ReadPin(ORION_CHARGE_ENABLE_SENSE_GPIO_Port, ORION_CHARGE_ENABLE_SENSE_Pin);
 
-            // Check if charge should trip the car
-            int chargeTrippedCar = chargeShouldTrip();
-
-            // Check if dicharge should trip the car
-            int dischargeTrippedCar = dischargeShouldTrip();
-
-            int protectionTripping = 0;
-
-            // If the charge contactor is off, but we are still charging, trip
-            if (!chargeSense && orionStatus.packCurrent < 0)
-            {
-                protectionTripping = 1;
-            }
-
-            // If both contactors should be off
-            if (chargeTrippedCar
-                    || dischargeTrippedCar
-                    || protectionTripping
-                    || (!dischargeSense && !chargeSense))
+            // If the car should trip or orion wants both contactors off
+            if (carShouldTrip() || (!orionDischargeEnableSense && !orionChargeEnableSense))
             {
                 // Trip car
                 chargeContactorOverride = 1;
@@ -91,7 +74,7 @@ void updateChargeAllowanceTask(void const* arg)
             else
             {
                 // Turn off discharge without tripping
-                if (!dischargeSense)
+                if (!orionDischargeEnableSense)
                 {
                     dischargeContactorOverride = 1;
                     allowDischarge = 0;
@@ -100,7 +83,7 @@ void updateChargeAllowanceTask(void const* arg)
                 }
 
                 // Turn off charge without tripping
-                if (!chargeSense)
+                if (!orionChargeEnableSense)
                 {
                     chargeContactorOverride = 1;
                     allowCharge = 0;


### PR DESCRIPTION
Previously, the inccorectly named chargeSense variable in updateChargeAllowanceTask refered to the orion ChargeEnableSense pin, for the orionBMS to communicate if it wants the charge pin on. However, it's usage in
```
            // If the charge contactor is off, but we are still charging, trip
            if (!chargeSense && orionStatus.packCurrent < 0)
            {
                protectionTripping = 1;
            }
``` 
Communicates that it wants the actual charge contactor sense! This should explain why Colton was able to charge the car past the internal Aux BMS limit when the charge contactor disenaged, as it was actually waiting for the higher Orion Limit to hit.