### PR TITLE
SFT 329 If isCurrentLow fails, trip the car

### DIFF
--- a/EpsilonAuxBmsV2/Core/Inc/Tasks/ChargeContactorGatekeeperTask.h
+++ b/EpsilonAuxBmsV2/Core/Inc/Tasks/ChargeContactorGatekeeperTask.h
@@ -1,7 +1,10 @@
 #pragma once
 #include "ContactorGatekeeper.h"
+#include "AuxTrip.h"
 
 extern osThreadId_t chargeContactorGatekeeperTaskHandle;
+extern AuxTrip auxTrip;
+extern osMutexId_t auxTripMutex;
 
 void closeChargeContactor();
 void openChargeContactor();

--- a/EpsilonAuxBmsV2/Core/Inc/Tasks/DischargeContactorGatekeeperTask.h
+++ b/EpsilonAuxBmsV2/Core/Inc/Tasks/DischargeContactorGatekeeperTask.h
@@ -1,8 +1,13 @@
 #pragma once
 #include "ContactorGatekeeper.h"
+#include "AuxStatus.h"
+#include "AuxTrip.h"
+#include "DisconnectContactors.h"
 
 extern osThreadId_t dischargeContactorGatekeeperTaskHandle;
 extern AuxBmsContactorState auxBmsContactorState;
+extern AuxTrip auxTrip;
+extern AuxStatus auxStatus;
 
 void dischargeContactorGatekeeperTask(void* arg);
 void closeDischargeContactor();

--- a/EpsilonAuxBmsV2/Core/Inc/Tasks/DischargeContactorGatekeeperTask.h
+++ b/EpsilonAuxBmsV2/Core/Inc/Tasks/DischargeContactorGatekeeperTask.h
@@ -1,13 +1,11 @@
 #pragma once
 #include "ContactorGatekeeper.h"
-#include "AuxStatus.h"
 #include "AuxTrip.h"
-#include "DisconnectContactors.h"
 
 extern osThreadId_t dischargeContactorGatekeeperTaskHandle;
 extern AuxBmsContactorState auxBmsContactorState;
 extern AuxTrip auxTrip;
-extern AuxStatus auxStatus;
+extern osMutexId_t auxTripMutex;
 
 void dischargeContactorGatekeeperTask(void* arg);
 void closeDischargeContactor();

--- a/EpsilonAuxBmsV2/Core/Inc/Types/AuxTrip.h
+++ b/EpsilonAuxBmsV2/Core/Inc/Types/AuxTrip.h
@@ -11,6 +11,6 @@ typedef struct
     unsigned dischargeTripDueToHighTemperatureAndCurrent : 1;
     unsigned dischargeTripDueToPackCurrent : 1;
     unsigned protectionTrip : 1;
-    unsigned dischargeTripDueToHighCurrent: 1;
-    unsigned chargeTripDueToHighCurrent: 1;
+    unsigned dischargeNotClosedDueToHighCurrent: 1;
+    unsigned chargeNotClosedDueToHighCurrent: 1;
 } AuxTrip;

--- a/EpsilonAuxBmsV2/Core/Inc/Types/AuxTrip.h
+++ b/EpsilonAuxBmsV2/Core/Inc/Types/AuxTrip.h
@@ -11,4 +11,6 @@ typedef struct
     unsigned dischargeTripDueToHighTemperatureAndCurrent : 1;
     unsigned dischargeTripDueToPackCurrent : 1;
     unsigned protectionTrip : 1;
+    unsigned dischargeTripDueToHighCurrent: 1;
+    unsigned chargeTripDueToHighCurrent: 1;
 } AuxTrip;

--- a/EpsilonAuxBmsV2/Core/Src/Tasks/ChargeContactorGatekeeperTask.c
+++ b/EpsilonAuxBmsV2/Core/Src/Tasks/ChargeContactorGatekeeperTask.c
@@ -37,6 +37,14 @@ void closeChargeContactor()
         auxBmsContactorState.chargeState = CONTACTOR_ERROR;
         HAL_GPIO_WritePin(CHARGE_ENABLE_GPIO_Port, CHARGE_ENABLE_Pin, GPIO_PIN_RESET);
 
+        if (!currentLow) { //something closed that isn't supposed to be 
+            if (osMutexAcquire(auxTripMutex, MUTEX_TIMEOUT) == osOK)
+            {
+                auxTrip.chargeNotClosedDueToHighCurrent = 1;
+                osMutexRelease(auxTripMutex);
+            }
+        }
+
         if (isDischargeClosed) // Discharge closed so delay and try again
         {
             osDelay(CONTACTOR_DELAY);

--- a/EpsilonAuxBmsV2/Core/Src/Tasks/DischargeContactorGatekeeperTask.c
+++ b/EpsilonAuxBmsV2/Core/Src/Tasks/DischargeContactorGatekeeperTask.c
@@ -38,6 +38,13 @@ void closeDischargeContactor()
         auxBmsContactorState.dischargeState = CONTACTOR_ERROR;
         HAL_GPIO_WritePin(DISCHARGE_ENABLE_GPIO_Port, DISCHARGE_ENABLE_Pin, GPIO_PIN_RESET);
 
+        if (!currentLow) { //means that something closed that isn't supposed to be and that's bad
+            
+            auxTrip.dischargeTripDueToHighCurrent = 1;
+            auxStatus.dischargeContactorError = 1;
+            disconnectContactors();
+        }
+
         if (isChargeClosed) // charge contactor closed so delay then try again
         {
             osDelay(CONTACTOR_DELAY);

--- a/EpsilonAuxBmsV2/Core/Src/Tasks/DischargeContactorGatekeeperTask.c
+++ b/EpsilonAuxBmsV2/Core/Src/Tasks/DischargeContactorGatekeeperTask.c
@@ -38,11 +38,12 @@ void closeDischargeContactor()
         auxBmsContactorState.dischargeState = CONTACTOR_ERROR;
         HAL_GPIO_WritePin(DISCHARGE_ENABLE_GPIO_Port, DISCHARGE_ENABLE_Pin, GPIO_PIN_RESET);
 
-        if (!currentLow) { //means that something closed that isn't supposed to be and that's bad
-            
-            auxTrip.dischargeTripDueToHighCurrent = 1;
-            auxStatus.dischargeContactorError = 1;
-            disconnectContactors();
+        if (!currentLow) { //something closed that isn't supposed to be 
+            if (osMutexAcquire(auxTripMutex, MUTEX_TIMEOUT) == osOK)
+            {
+                auxTrip.dischargeNotClosedDueToHighCurrent = 1;
+                osMutexRelease(auxTripMutex);
+            }
         }
 
         if (isChargeClosed) // charge contactor closed so delay then try again

--- a/EpsilonAuxBmsV2/Core/Src/Tasks/OrionFunctions/Trip.c
+++ b/EpsilonAuxBmsV2/Core/Src/Tasks/OrionFunctions/Trip.c
@@ -60,29 +60,33 @@ void updateAuxTrip(OrionCanInfo* message, AuxTrip* auxTripToUpdate)
 }
 
 /*
-Determines whether Discharge should cause a trip based on Orion CAN messages
+Determines whether Discharge should cause a trip based on Orion CAN messages and current line between contactors
 Discharge will cause a trip due to:
   * the min cell voltage being lower than the Orion limit
   * high temperature while discharging
   * discharge pack current being too high
+  * current line between contactors not low enough to close discharge
 */
 uint8_t checkDischargeTrip(AuxTrip auxTrip)
 {
     return auxTrip.dischargeTripDueToLowCellVoltage ||
            auxTrip.dischargeTripDueToHighTemperatureAndCurrent ||
-           auxTrip.dischargeTripDueToPackCurrent;
+           auxTrip.dischargeTripDueToPackCurrent ||
+           auxTrip.dischargeNotClosedDueToHighCurrent; //set in discharge gatekeeper task
 }
 
 /*
-Determines whether charge should cause a trip based on Orion CAN messages
+Determines whether charge should cause a trip based on Orion CAN messages and current line between contactors
 Charge will cause a trip due to:
   * the max cell voltage being higher than the Orion limit
   * high temperature while charging
   * discharge pack current being too high (absolute value)
+  * current line between contactors not low enough to close charge
 */
 uint8_t checkChargeTrip(AuxTrip auxTrip)
 {
     return auxTrip.chargeTripDueToHighCellVoltage ||
            auxTrip.chargeTripDueToHighTemperatureAndCurrent ||
-           auxTrip.chargeTripDueToPackCurrent;
+           auxTrip.chargeTripDueToPackCurrent ||
+           auxTrip.chargeNotClosedDueToHighCurrent; //set in charge gatekeeper task
 }

--- a/EpsilonAuxBmsV2/Core/Src/Tasks/SendAuxTripTask.c
+++ b/EpsilonAuxBmsV2/Core/Src/Tasks/SendAuxTripTask.c
@@ -28,7 +28,7 @@ void sendAuxTrip(CanTxGatekeeperQueueData* canQueueData, uint32_t* prevWakeTime)
     {
         canQueueData->canTxHeader = BASE_CAN_TX_HDR;
         canQueueData->canTxHeader.StdId = AUX_TRIP_STDID;
-        canQueueData->canTxHeader.DLC = 1;
+        canQueueData->canTxHeader.DLC = 2;
         canQueueData->data[0] = auxTrip.chargeTripDueToHighCellVoltage |
                                 (auxTrip.chargeTripDueToHighTemperatureAndCurrent << 1) |
                                 (auxTrip.chargeTripDueToPackCurrent << 2) |
@@ -36,6 +36,8 @@ void sendAuxTrip(CanTxGatekeeperQueueData* canQueueData, uint32_t* prevWakeTime)
                                 (auxTrip.dischargeTripDueToHighTemperatureAndCurrent << 4) |
                                 (auxTrip.dischargeTripDueToPackCurrent << 5) |
                                 (auxTrip.protectionTrip << 6);
+        canQueueData->data[1] = auxTrip.chargeNotClosedDueToHighCurrent |
+                                (auxTrip.dischargeNotClosedDueToHighCurrent << 1);
         osMessageQueuePut(canTxGatekeeperQueue, canQueueData, 0, TASK_QUEUE_PUT_TIMEOUT);
         osMutexRelease(auxTripMutex);
     }


### PR DESCRIPTION
Implement this for charge and discharge using additional AuxTrip elements: Discharge Not Closed Due To High Current, Charge Not Closed Due To High Current which will prompt Orion to do the tripping. This is to keep the functionality in the gatekeeper tasks limited to opening and closing contactors. 

Yet to add the two elements to send in to CAN, need to change the Communications Protocol. 

